### PR TITLE
OP-813: Changed overlapping gql permissions

### DIFF
--- a/report/apps.py
+++ b/report/apps.py
@@ -9,9 +9,9 @@ MODULE_NAME = "report"
 
 DEFAULT_CFG = {
     "gql_query_report_perms": ["131200"],
-    "gql_mutation_report_add_perms": ["121002"],
-    "gql_mutation_report_edit_perms": ["121003"],
-    "gql_mutation_report_delete_perms": ["121004"],
+    "gql_mutation_report_add_perms": ["131201"],
+    "gql_mutation_report_edit_perms": ["131202"],
+    "gql_mutation_report_delete_perms": ["131203"],
 }
 
 

--- a/report/migrations/0003_update_permissions.py
+++ b/report/migrations/0003_update_permissions.py
@@ -1,0 +1,27 @@
+from django.db import migrations
+
+
+def assign_updated_report_permissions(apps, schema_editor):
+    from core.models import RoleRight, Role
+    role_ids = RoleRight.objects.filter(right_id=131200).values_list('role__id', flat=True)
+
+    relevant_roles = Role.objects\
+        .filter(id__in=role_ids)\
+        .filter(validity_to__isnull=True)\
+        .all()
+
+    new_perms = [131201, 131202, 131203]
+    for role in relevant_roles:
+        new_rights = [RoleRight(role=role, right_id=right, audit_user_id=None) for right in new_perms]
+        RoleRight.objects.bulk_create(new_rights)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('report', '0002_auto_20220308_1414'),
+    ]
+
+    operations = [
+        migrations.RunPython(assign_updated_report_permissions),
+    ]


### PR DESCRIPTION
Report create, update and delete GQL permissions were conflicting with product permissions.
Right IDs were changed to unique ones, additionally migration that'll grant new Right IDs to roles that already have generic `gql_query_report_perms` was added. 
TICKET: [OP-813](https://openimis.atlassian.net/browse/OP-813)